### PR TITLE
add %SECONDS% and %MILLIS% formatters

### DIFF
--- a/src/main/java/com/github/maxopoly/kira/relay/RelayConfig.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/RelayConfig.java
@@ -80,6 +80,8 @@ public class RelayConfig {
 		output = output.replace("%MESSAGE%", DiscordMsgUtil.escape(action.getMessage()));
 		output = output.replace("%GROUP%", action.getGroupName());
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
+		output = output.replace("%SECONDS%", String.valueOf(action.getTimeStamp() / 1000));
+		output = output.replace("%MILLIS%", String.valueOf(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;
 	}
@@ -88,6 +90,8 @@ public class RelayConfig {
 		String output = newPlayerFormat;
 		output = output.replace("%PLAYER%", DiscordMsgUtil.escape(action.getPlayer()));
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
+		output = output.replace("%SECONDS%", String.valueOf(action.getTimeStamp() / 1000));
+		output = output.replace("%MILLIS%", String.valueOf(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;
 	}
@@ -108,6 +112,8 @@ public class RelayConfig {
 		output = output.replace("%ACTION%", actionString);
 		output = output.replace("%PLAYER%", DiscordMsgUtil.escape(action.getPlayer()));
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
+		output = output.replace("%SECONDS%", String.valueOf(action.getTimeStamp() / 1000));
+		output = output.replace("%MILLIS%", String.valueOf(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;
 	}
@@ -138,6 +144,8 @@ public class RelayConfig {
 		output = output.replaceAll("%PLAYER%", DiscordMsgUtil.escape(action.getPlayerName()));
 		output = output.replace("%GROUP%", action.getGroupName());
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
+		output = output.replace("%SECONDS%", String.valueOf(action.getTimeStamp() / 1000));
+		output = output.replace("%MILLIS%", String.valueOf(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;
 	}


### PR DESCRIPTION
Using the existing `timeformat` relay config option unfortunately does not work, as it [does not support UNIX seconds](https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html#patterns). 

This suggestion has been discussed on Discord: https://discord.com/channels/912074050086502470/1404240457181167616