### PR TITLE
Add %SERVER% formatter

### DIFF
--- a/src/main/java/com/github/maxopoly/kira/command/discord/relay/ConfigureRelayConfigCommand.java
+++ b/src/main/java/com/github/maxopoly/kira/command/discord/relay/ConfigureRelayConfigCommand.java
@@ -128,10 +128,10 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 			reply.append(" - Format used for group chat messages (chatformat): " + verbatimFormat(relay.getChatFormat()) + "\n");
 			reply.append(
 					"    Example: " + relay.formatChatMessage(new GroupChatMessageAction(System.currentTimeMillis(),
-							"exampleGroup", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "hello, this is an example message")) + "\n");
+							"exampleServer", "exampleGroup", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "hello, this is an example message")) + "\n");
 			reply.append(" - Format used for snitch alerts (snitchformat): " + verbatimFormat(relay.getSnitchFormat()) + "\n");
 			reply.append("    Example: " + relay.formatSnitchOutput(
-					new PlayerHitSnitchAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "SecretBaseSnitch", "exampleGroup",
+					new PlayerHitSnitchAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "SecretBaseSnitch", "exampleGroup",
 							new MinecraftLocation("world", 420, 100, 420), SnitchHitType.ENTER, SnitchType.ENTRY))
 					+ "\n");
 			reply.append(" - Format used for entering a snitch range (snitchentermessage): "
@@ -154,7 +154,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 					+ relay.isSkynetEnabled() + "\n");
 			reply.append(" - Skynet format (skynetformat): " + verbatimFormat(relay.getSkynetFormat()) + "\n");
 			reply.append("    Example: "
-					+ relay.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGIN))
+					+ relay.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGIN))
 					+ "\n");
 			reply.append(" - Skynet login format (skynetloginformat): " + relay.getSkynetLoginString() + "\n");
 			reply.append(" - Skynet logout format (skynetlogoutformat): " + relay.getSkynetLogoutString() + "\n");
@@ -162,7 +162,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 					+ relay.isNewPlayerEnabled() + "\n");
 			reply.append(" - new player announcement format (newplayerformat): " + verbatimFormat(relay.getNewPlayerFormat()) + "\n");
 			reply.append("    Example: "
-					+ relay.formatNewPlayerMessage(new NewPlayerAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51")))
+					+ relay.formatNewPlayerMessage(new NewPlayerAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51")))
 					+ "\n");
 			reply.append(" - Use \"help relayconfig\" for more information on how to configure these properties\n");
 			return reply.toString();
@@ -214,7 +214,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				relay.updateChatFormat(arguments);
 				reply.append("Example chat message would look like this:\n");
 				reply.append(relay.formatChatMessage(new GroupChatMessageAction(System.currentTimeMillis(),
-						"exampleGroup", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "hello, this is an example message")));
+						"exampleServer", "exampleGroup", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "hello, this is an example message")));
 				reply.append('\n');
 				checkPingAbility(relay, reply);
 			}
@@ -224,7 +224,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				reply.append("Setting snitch alert format to: " + arguments + "\n");
 				relay.setSnitchFormat(arguments);
 				reply.append("Example snitch message would look like this:\n");
-				reply.append(relay.formatSnitchOutput(new PlayerHitSnitchAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"),
+				reply.append(relay.formatSnitchOutput(new PlayerHitSnitchAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"),
 						"SecretBaseSnitch", "exampleGroup", new MinecraftLocation("world", 420, 100, 420),
 						SnitchHitType.ENTER, SnitchType.ENTRY)));
 				reply.append('\n');
@@ -238,7 +238,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				reply.append("Setting login message to: " + arguments + "\n");
 				relay.updateLoginAction(arguments);
 				reply.append("Example snitch message would look like this:\n");
-				reply.append(new PlayerHitSnitchAction(System.currentTimeMillis(), "ttk2",  UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"),"SecretBaseSnitch",
+				reply.append(new PlayerHitSnitchAction(System.currentTimeMillis(), "exampleServer", "ttk2",  UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"),"SecretBaseSnitch",
 						"exampleGroup", new MinecraftLocation("world", 420, 100, 420), SnitchHitType.LOGIN,
 						SnitchType.ENTRY));
 			}
@@ -249,7 +249,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 			if (passLengthCheck(arguments, 256, reply)) {
 				reply.append("Setting logout message to: " + arguments + "\n");
 				relay.updateLogoutAction(arguments);
-				reply.append(new PlayerHitSnitchAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "SecretBaseSnitch",
+				reply.append(new PlayerHitSnitchAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "SecretBaseSnitch",
 						"exampleGroup", new MinecraftLocation("world", 420, 100, 420), SnitchHitType.LOGOUT,
 						SnitchType.ENTRY));
 			}
@@ -260,7 +260,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 			if (passLengthCheck(arguments, 256, reply)) {
 				reply.append("Setting enter message to: " + arguments + "\n");
 				relay.updateEnterAction(arguments);
-				reply.append(new PlayerHitSnitchAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "SecretBaseSnitch",
+				reply.append(new PlayerHitSnitchAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), "SecretBaseSnitch",
 						"exampleGroup", new MinecraftLocation("world", 420, 100, 420), SnitchHitType.ENTER,
 						SnitchType.ENTRY));
 			}
@@ -327,7 +327,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				relay.updateSkynetFormat(arguments);
 				reply.append("Example skynet message would look like this:\n");
 				reply.append(relay
-						.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGIN)));
+						.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGIN)));
 				reply.append('\n');
 			}
 			break;
@@ -338,7 +338,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				relay.updateSkynetLoginString(arguments);
 				reply.append("Example skynet login message would look like this:\n");
 				reply.append(relay
-						.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGIN)));
+						.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGIN)));
 				reply.append('\n');
 			}
 			break;
@@ -349,7 +349,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				relay.updateSkynetLogoutString(arguments);
 				reply.append("Example skynet logout message would look like this:\n");
 				reply.append(relay
-						.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGOUT)));
+						.formatSkynetMessage(new SkynetAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"), SkynetType.LOGOUT)));
 				reply.append('\n');
 			}
 			break;
@@ -366,7 +366,7 @@ public class ConfigureRelayConfigCommand extends ArgumentBasedCommand {
 				relay.updateNewPlayerFormat(arguments);
 				reply.append("Example new player announcements message would look like this:\n");
 				reply.append(relay
-						.formatNewPlayerMessage(new NewPlayerAction(System.currentTimeMillis(), "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"))));
+						.formatNewPlayerMessage(new NewPlayerAction(System.currentTimeMillis(), "exampleServer", "ttk2", UUID.fromString("8326bc56-1ed9-40ff-8f24-46bf3e300e51"))));
 				reply.append('\n');
 			}
 			break;

--- a/src/main/java/com/github/maxopoly/kira/rabbit/input/NewPlayerMessage.java
+++ b/src/main/java/com/github/maxopoly/kira/rabbit/input/NewPlayerMessage.java
@@ -19,9 +19,10 @@ public class NewPlayerMessage extends RabbitMessage {
         UUID playerUUID = UUID.fromString(json.getString("playerUUID"));
         long timestamp = json.optLong("timestamp", System.currentTimeMillis());
 
-        NewPlayerAction action = new NewPlayerAction(timestamp, player, playerUUID);
+        String server = json.getString("server");
+        NewPlayerAction action = new NewPlayerAction(timestamp, server, player, playerUUID);
         KiraMain.getInstance().getAPISessionManager().handleNewPlayerMessage(action);
-        KiraMain.getInstance().getGroupChatManager().applyToAll(json.getString("server"), chat -> {
+        KiraMain.getInstance().getGroupChatManager().applyToAll(server, chat -> {
             chat.sendNewPlayer(action);
         });
     }

--- a/src/main/java/com/github/maxopoly/kira/rabbit/input/SendGroupChatMessage.java
+++ b/src/main/java/com/github/maxopoly/kira/rabbit/input/SendGroupChatMessage.java
@@ -25,7 +25,7 @@ public class SendGroupChatMessage extends RabbitMessage {
 		UUID senderUUID = UUID.fromString(json.getString("senderUUID"));
 		long timestamp = json.optLong("timestamp", System.currentTimeMillis());
 
-		GroupChatMessageAction action = new GroupChatMessageAction(timestamp, group, sender, senderUUID, msg);
+		GroupChatMessageAction action = new GroupChatMessageAction(timestamp, server, group, sender, senderUUID, msg);
 		KiraMain.getInstance().getAPISessionManager().handleGroupMessage(action);
 		GroupChatManager man = KiraMain.getInstance().getGroupChatManager();
 		GroupChat chat = man.getGroupChat(new GroupId(server, group.toLowerCase()));

--- a/src/main/java/com/github/maxopoly/kira/rabbit/input/SkynetMessage.java
+++ b/src/main/java/com/github/maxopoly/kira/rabbit/input/SkynetMessage.java
@@ -21,8 +21,9 @@ public class SkynetMessage extends RabbitMessage {
 		SkynetType type = SkynetType.valueOf(json.getString("action").toUpperCase());
 		long timestamp = json.optLong("timestamp", System.currentTimeMillis());
 
-		SkynetAction action = new SkynetAction(timestamp, player, playerUUID, type);
+		String server = json.getString("server");
+		SkynetAction action = new SkynetAction(timestamp, server, player, playerUUID, type);
 		KiraMain.getInstance().getAPISessionManager().handleSkynetMessage(action);
-		KiraMain.getInstance().getGroupChatManager().applyToAll(json.getString("server"), chat -> {chat.sendSkynet(action);});
+		KiraMain.getInstance().getGroupChatManager().applyToAll(server, chat -> {chat.sendSkynet(action);});
 	}
 }

--- a/src/main/java/com/github/maxopoly/kira/rabbit/input/SnitchHitMessage.java
+++ b/src/main/java/com/github/maxopoly/kira/rabbit/input/SnitchHitMessage.java
@@ -41,7 +41,7 @@ public class SnitchHitMessage extends RabbitMessage {
 		SnitchHitType hitType = SnitchHitType.valueOf(json.optString("type", "ENTER"));
 		SnitchType snitchType = SnitchType.getType(json.optString("snitchtype", "ENTRY"));
 		long timestamp = json.optLong("timestamp", System.currentTimeMillis());
-		PlayerHitSnitchAction snitchAction = new PlayerHitSnitchAction(timestamp, victimName, victimUUID, snitchName, groupName,
+		PlayerHitSnitchAction snitchAction = new PlayerHitSnitchAction(timestamp, server, victimName, victimUUID, snitchName, groupName,
 				new MinecraftLocation(world, x, y, z), hitType, snitchType);
 		KiraMain.getInstance().getAPISessionManager().handleSnitchHit(snitchAction);
 		if (!chat.sendSnitchHit(snitchAction)) {

--- a/src/main/java/com/github/maxopoly/kira/relay/RelayConfig.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/RelayConfig.java
@@ -81,6 +81,7 @@ public class RelayConfig {
 		output = output.replace("%PLAYERUUID%", action.getSenderUUID().toString());
 		output = output.replace("%MESSAGE%", DiscordMsgUtil.escape(action.getMessage()));
 		output = output.replace("%GROUP%", action.getGroupName());
+		output = output.replace("%SERVER%", action.getServer());
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;
@@ -91,6 +92,7 @@ public class RelayConfig {
         output = output.replace("%PLAYER%", DiscordMsgUtil.escape(action.getPlayer()));
         output = output.replace("%PLAYERRAW%", action.getPlayer());
 		output = output.replace("%PLAYERUUID%", action.getPlayerUUID().toString());
+		output = output.replace("%SERVER%", action.getServer());
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;
@@ -113,6 +115,7 @@ public class RelayConfig {
 		output = output.replace("%PLAYER%", DiscordMsgUtil.escape(action.getPlayer()));
         output = output.replace("%PLAYERRAW%", action.getPlayer());
 		output = output.replace("%PLAYERUUID%", action.getPlayerUUID().toString());
+		output = output.replace("%SERVER%", action.getServer());
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;
@@ -145,6 +148,7 @@ public class RelayConfig {
         output = output.replaceAll("%PLAYERRAAW%", action.getPlayerName());
 		output = output.replace("%PLAYERUUID%", action.getPlayerUUID().toString());
 		output = output.replace("%GROUP%", action.getGroupName());
+		output = output.replace("%SERVER%", action.getServer());
 		output = output.replace("%TIME%", getFormattedTime(action.getTimeStamp()));
 		output = reformatPings(output);
 		return output;

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/GroupChatMessageAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/GroupChatMessageAction.java
@@ -10,8 +10,8 @@ public class GroupChatMessageAction extends MinecraftAction {
 	private UUID senderUUID;
 	private String message;
 
-	public GroupChatMessageAction(long timeStamp, String group, String sender, UUID senderUUID, String message) {
-		super(timeStamp);
+	public GroupChatMessageAction(long timeStamp, String server, String group, String sender, UUID senderUUID, String message) {
+		super(timeStamp, server);
 		this.group = group;
 		this.sender = sender;
 		this.senderUUID = senderUUID;

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/MinecraftAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/MinecraftAction.java
@@ -24,6 +24,7 @@ public abstract class MinecraftAction {
 	private JSONObject constructJSON() {
 		JSONObject json = new JSONObject();
 		json.put("time", timeStamp);
+		json.put("server", server);
 		internalConstructJSON(json);
 		return json;
 	}

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/MinecraftAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/MinecraftAction.java
@@ -9,10 +9,16 @@ import org.json.JSONObject;
 public abstract class MinecraftAction {
 
 	private final long timeStamp;
+	private final String server;
 	private JSONObject json;
 
-	public MinecraftAction(long timeStamp) {
+	public MinecraftAction(long timeStamp, String server) {
 		this.timeStamp = timeStamp;
+		this.server = server;
+	}
+
+	public String getServer() {
+		return server;
 	}
 
 	private JSONObject constructJSON() {

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/NewPlayerAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/NewPlayerAction.java
@@ -8,8 +8,8 @@ public class NewPlayerAction extends MinecraftAction {
 	private final String player;
 	private final UUID playerUUID;
 
-	public NewPlayerAction(long timestamp, String player, UUID playerUUID) {
-		super(timestamp);
+	public NewPlayerAction(long timestamp, String server, String player, UUID playerUUID) {
+		super(timestamp, server);
 		this.player = player;
 		this.playerUUID = playerUUID;
 	}

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/PlayerHitSnitchAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/PlayerHitSnitchAction.java
@@ -13,9 +13,9 @@ public class PlayerHitSnitchAction extends MinecraftAction {
 	private String groupName;
 	private SnitchType snitchType;
 
-	public PlayerHitSnitchAction(long timestamp, String playerName, UUID playerUUID, String snitchname, String groupName,
+	public PlayerHitSnitchAction(long timestamp, String server, String playerName, UUID playerUUID, String snitchname, String groupName,
 								 MinecraftLocation location, SnitchHitType hitType, SnitchType snitchType) {
-		super(timestamp);
+		super(timestamp, server);
 		this.playerName = playerName;
 		this.playerUUID = playerUUID;
 		this.snitchName = snitchname;

--- a/src/main/java/com/github/maxopoly/kira/relay/actions/SkynetAction.java
+++ b/src/main/java/com/github/maxopoly/kira/relay/actions/SkynetAction.java
@@ -9,8 +9,8 @@ public class SkynetAction extends MinecraftAction {
 	private final String player;
 	private final UUID playerUUID;
 
-	public SkynetAction(long timestamp, String player, UUID playerUUID, SkynetType type) {
-		super(timestamp);
+	public SkynetAction(long timestamp, String server, String player, UUID playerUUID, SkynetType type) {
+		super(timestamp, server);
 		this.player = player;
 		this.playerUUID = playerUUID;
 		this.type = type;


### PR DESCRIPTION
Add %SERVER% formatter, so that events (skynet, snitch, chat, etc) can reliably be associated to the specific server which generated them.

This option is useful for allowing bots or users to identify which server a message came from, and so.

Without this option, it is impossible to reliably know which server a specific message originates from, without configuring the bot in some specific way (i.e: hard-coding a server identifier in the format string itself, OR keeping mini and main traffic to strictly separate channels and configuring/noting which is which manually). This is because multiple servers can theoretically have the same namelayer name, relayed to the same channel. This resolves that in an easy-to-use way.